### PR TITLE
dtbhtool: Add new DTBH_MODEL entry

### DIFF
--- a/dtbhtool/dtbimg.c
+++ b/dtbhtool/dtbimg.c
@@ -126,6 +126,7 @@ void *load_dtbh_block(const char *dtb_path, unsigned pagesize, unsigned *_sz)
     uint32_t version = DTBH_VERSION;
     unsigned blob_sz = 0;
     char fname[PATH_MAX];
+    const unsigned *model;
     const unsigned *prop_chip;
     const unsigned *prop_platform;
     const unsigned *prop_subtype;
@@ -161,6 +162,17 @@ void *load_dtbh_block(const char *dtb_path, unsigned pagesize, unsigned *_sz)
         }
 
         offset = fdt_path_offset(dtb, "/");
+
+#ifdef DTBH_MODEL
+        model = fdt_getprop(dtb, offset, "model", &len);
+        if (strstr((char *)&model[0], DTBH_MODEL) == NULL) {
+            warnx("model of %s is invalid, skipping (expected *%s* but got %s)",
+                  fname, DTBH_MODEL, (char *)&model[0]);
+            free(dtb);
+            continue;
+        }
+#endif
+
         prop_chip = fdt_getprop(dtb, offset, "model_info-chip", &len);
         if (len % (sizeof(uint32_t)) != 0) {
             warnx("model_info-chip of %s is of invalid size, skipping", fname);


### PR DESCRIPTION
This allows us to distinguish not only by platform and subtype at build
time, but also by device-specific model.

It is required because two devices may share the same kernel sources and
thus build the same dtbs, but the resulting dt.img should be devie
specific and only contain the specific dtbs for that device.
Otherwise we are likely to violate dt.img size constraints by including
too many dtbs (which is the case for a5y17lte and a7y17lte right now).

For now, the feature will be optional (existing samsung_dtbh.h headers
don't have to be changed) but that might change in the future.

Change-Id: I2d804f9f1a14051e60f4de4f3d2d4f11c9b3c23f